### PR TITLE
修复获取存储完整路径不正确 && 更改本地默认上传路径

### DIFF
--- a/config/filesystem.php
+++ b/config/filesystem.php
@@ -9,7 +9,7 @@ return [
     'disks'   => [
         'local'  => [
             'type' => 'local',
-            'root' =>  app()->getRootPath() . 'public/images',
+            'root' =>  'upload',
             'domain' => env('API_URL'),
         ],
         'public' => [


### PR DESCRIPTION
配置文件中的app()->getRootPath()会让getCloudDomain带有F:/xxx/xxx这样的路径最后形成 http://xxx.com/F:/xx/xxx/upload.jpg 这样的完整路径，去掉就行了。

然后更改root的默认值images为upload，上传不一定是图片，感觉upload目录更合适。