### PR TITLE
fix： 修复执行安装时，password 字段重复加密。

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/framework": "^9.44",
         "laravel/tinker": "^2.7",
         "tymon/jwt-auth": "dev-develop",
-        "catchadmin/core": "^0.1.1"
+        "catchadmin/core": "^0.1.3"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/modules/User/database/seeder/User.php
+++ b/modules/User/database/seeder/User.php
@@ -18,7 +18,7 @@ return new class extends Seeder
 
             'email' => 'catch@admin.com',
 
-            'password' => bcrypt('catchadmin'),
+            'password' => 'catchadmin',
 
             'creator_id' => 1,
 


### PR DESCRIPTION
在`Modules\User\Models\User` 已有执行加密，执行seed时不需要再执行。
https://github.com/JaguarJack/catch-admin/blob/37a232aee87608cd6b707a29be35c60d8a7dedf5/modules/User/Models/User.php#L88